### PR TITLE
Use Spring AI for chunking, embeddings and indexing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,18 @@
         <java.version>17</java.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-bom</artifactId>
+                <version>1.0.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Spring Boot starters -->
         <dependency>
@@ -73,6 +85,16 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-search-documents</artifactId>
+        </dependency>
+
+        <!-- Spring AI -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-azure-openai</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-vector-store-azure</artifactId>
         </dependency>
     </dependencies>
 

--- a/rag-ingestion-kafka/src/main/java/com/example/ingestion/service/SpringAiEmbeddingService.java
+++ b/rag-ingestion-kafka/src/main/java/com/example/ingestion/service/SpringAiEmbeddingService.java
@@ -1,0 +1,23 @@
+package com.example.ingestion.service;
+
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Primary
+public class SpringAiEmbeddingService implements EmbeddingService {
+
+    private final EmbeddingModel embeddingModel;
+
+    public SpringAiEmbeddingService(EmbeddingModel embeddingModel) {
+        this.embeddingModel = embeddingModel;
+    }
+
+    @Override
+    public List<float[]> embed(List<String> chunks) {
+        return embeddingModel.embed(chunks);
+    }
+}

--- a/rag-ingestion-kafka/src/main/java/com/example/ingestion/service/SpringAiVectorStoreService.java
+++ b/rag-ingestion-kafka/src/main/java/com/example/ingestion/service/SpringAiVectorStoreService.java
@@ -1,0 +1,34 @@
+package com.example.ingestion.service;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Primary
+public class SpringAiVectorStoreService implements VectorIndexService {
+
+    private final VectorStore vectorStore;
+
+    public SpringAiVectorStoreService(VectorStore vectorStore) {
+        this.vectorStore = vectorStore;
+    }
+
+    @Override
+    public void index(List<float[]> vectors, List<String> chunks, String filename) {
+        List<Document> docs = new ArrayList<>();
+        for (int i = 0; i < chunks.size(); i++) {
+            Map<String, Object> metadata = new HashMap<>();
+            metadata.put("filename", filename);
+            metadata.put("chunk", i);
+            docs.add(new Document(chunks.get(i), metadata));
+        }
+        vectorStore.add(docs);
+    }
+}

--- a/rag-ingestion-kafka/src/main/java/com/example/ingestion/service/TextChunker.java
+++ b/rag-ingestion-kafka/src/main/java/com/example/ingestion/service/TextChunker.java
@@ -1,18 +1,22 @@
 package com.example.ingestion.service;
 
+import org.springframework.ai.document.Document;
+import org.springframework.ai.transformer.splitter.TokenTextSplitter;
 import org.springframework.stereotype.Service;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
 public class TextChunker {
 
+    private final TokenTextSplitter splitter = new TokenTextSplitter();
+
     public List<String> chunk(String text) {
-        return Arrays.stream(text.split("\n\n"))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
+        Document doc = new Document(text, Map.of());
+        return splitter.split(doc).stream()
+                .map(Document::getText)
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Summary
- wire in Spring AI BOM and starter dependencies
- switch text chunking to use Spring AI token splitter
- implement embedding and vector store services with Spring AI

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685a5bb055ac8330a959f7901c8a4c44