### PR TITLE
Refactor with Spring AI ETL interfaces

### DIFF
--- a/src/main/java/com/example/ingestion/etl/Extractor.java
+++ b/src/main/java/com/example/ingestion/etl/Extractor.java
@@ -1,0 +1,10 @@
+package com.example.ingestion.etl;
+
+/**
+ * Simple contract for extracting data from an input source.
+ * @param <I> input type
+ * @param <O> extracted type
+ */
+public interface Extractor<I, O> {
+    O extract(I input) throws Exception;
+}

--- a/src/main/java/com/example/ingestion/etl/Loader.java
+++ b/src/main/java/com/example/ingestion/etl/Loader.java
@@ -1,0 +1,9 @@
+package com.example.ingestion.etl;
+
+/**
+ * Loads transformed data to a target system.
+ * @param <T> input type
+ */
+public interface Loader<T> {
+    void load(T input) throws Exception;
+}

--- a/src/main/java/com/example/ingestion/etl/Transformer.java
+++ b/src/main/java/com/example/ingestion/etl/Transformer.java
@@ -1,0 +1,10 @@
+package com.example.ingestion.etl;
+
+/**
+ * Transforms input data into another representation.
+ * @param <I> input type
+ * @param <O> output type
+ */
+public interface Transformer<I, O> {
+    O transform(I input) throws Exception;
+}

--- a/src/main/java/com/example/ingestion/kafka/listener/ChunkingListener.java
+++ b/src/main/java/com/example/ingestion/kafka/listener/ChunkingListener.java
@@ -32,7 +32,7 @@ public class ChunkingListener {
         String filename = event.filename();
         logger.info("Starting chunking for file: {}", filename);
         try {
-            List<String> chunks = chunker.chunk(event.text());
+            List<String> chunks = chunker.transform(event.text());
             kafkaTemplate.send("text.chunked", new ChunksGeneratedEvent(filename, chunks));
             logger.info("Chunking successful for file: {}", filename);
             retryCounts.remove(filename);

--- a/src/main/java/com/example/ingestion/service/EmbeddingService.java
+++ b/src/main/java/com/example/ingestion/service/EmbeddingService.java
@@ -2,6 +2,17 @@ package com.example.ingestion.service;
 
 import java.util.List;
 
-public interface EmbeddingService {
+import com.example.ingestion.etl.Transformer;
+
+/**
+ * Abstraction over an embedding model.
+ */
+public interface EmbeddingService extends Transformer<List<String>, List<float[]>> {
+
     List<float[]> embed(List<String> chunks);
+
+    @Override
+    default List<float[]> transform(List<String> input) {
+        return embed(input);
+    }
 }

--- a/src/main/java/com/example/ingestion/service/SpringAiEmbeddingService.java
+++ b/src/main/java/com/example/ingestion/service/SpringAiEmbeddingService.java
@@ -1,0 +1,23 @@
+package com.example.ingestion.service;
+
+import java.util.List;
+
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Embedding service backed by Spring AI {@link EmbeddingModel}.
+ */
+@Service
+@RequiredArgsConstructor
+public class SpringAiEmbeddingService implements EmbeddingService {
+
+    private final EmbeddingModel embeddingModel;
+
+    @Override
+    public List<float[]> embed(List<String> chunks) {
+        return embeddingModel.embed(chunks);
+    }
+}

--- a/src/main/java/com/example/ingestion/service/TextChunker.java
+++ b/src/main/java/com/example/ingestion/service/TextChunker.java
@@ -2,14 +2,17 @@ package com.example.ingestion.service;
 
 import org.springframework.stereotype.Service;
 
+import com.example.ingestion.etl.Transformer;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
-public class TextChunker {
+public class TextChunker implements Transformer<String, List<String>> {
 
-    public List<String> chunk(String text) {
+    @Override
+    public List<String> transform(String text) {
         return Arrays.stream(text.split("\n\n"))
                      .map(String::trim)
                      .filter(s -> !s.isEmpty())

--- a/src/main/java/com/example/ingestion/service/TextExtractorService.java
+++ b/src/main/java/com/example/ingestion/service/TextExtractorService.java
@@ -5,11 +5,14 @@ import org.apache.tika.parser.AutoDetectParser;
 import org.apache.tika.sax.BodyContentHandler;
 import org.springframework.stereotype.Service;
 
+import com.example.ingestion.etl.Extractor;
+
 import java.io.InputStream;
 
 @Service
-public class TextExtractorService {
+public class TextExtractorService implements Extractor<InputStream, String> {
 
+    @Override
     public String extract(InputStream inputStream) {
         try {
             AutoDetectParser parser = new AutoDetectParser();

--- a/src/main/java/com/example/ingestion/service/VectorIndexService.java
+++ b/src/main/java/com/example/ingestion/service/VectorIndexService.java
@@ -2,10 +2,13 @@ package com.example.ingestion.service;
 
 import java.util.List;
 
+import com.example.ingestion.etl.Loader;
+import com.example.ingestion.model.EmbeddingGeneratedEvent;
+
 /**
  * Simple abstraction for indexing embedding vectors.
  */
-public interface VectorIndexService {
+public interface VectorIndexService extends Loader<EmbeddingGeneratedEvent> {
     /**
      * Index the given vectors and their corresponding text chunks for the specified filename.
      *
@@ -14,4 +17,9 @@ public interface VectorIndexService {
      * @param filename the name of the source file
      */
     void index(List<float[]> vectors, List<String> chunks, String filename);
+
+    @Override
+    default void load(EmbeddingGeneratedEvent event) {
+        index(event.embeddings(), event.chunks(), event.filename());
+    }
 }

--- a/src/test/java/com/example/ingestion/service/TextChunkerTest.java
+++ b/src/test/java/com/example/ingestion/service/TextChunkerTest.java
@@ -13,7 +13,7 @@ public class TextChunkerTest {
     @Test
     public void testChunk() {
         String text = "Paragraph one.\n\nParagraph two.";
-        List<String> chunks = chunker.chunk(text);
+        List<String> chunks = chunker.transform(text);
         assertEquals(2, chunks.size());
         assertTrue(chunks.get(0).contains("Paragraph one"));
     }


### PR DESCRIPTION
## Summary
- introduce small ETL abstraction (`Extractor`, `Transformer`, `Loader`)
- refactor text extraction and chunking services to implement those interfaces
- extend `EmbeddingService` and `VectorIndexService` with ETL behavior
- add `SpringAiEmbeddingService` that delegates to Spring AI `EmbeddingModel`
- update listener and tests to new method names

## Testing
- `java -version`

------
https://chatgpt.com/codex/tasks/task_e_686157334fd4833097a9197b331c0b93