### PR TITLE
Upgrade to Spring Boot 3.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.5</version>
+        <version>3.4.7</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <spring.boot.version>3.2.5</spring.boot.version>
+        <spring.boot.version>3.4.7</spring.boot.version>
         <h2.version>2.3.232</h2.version>
         <flyway.version>11.8.2</flyway.version>
         <lombok.version>1.18.38</lombok.version>
@@ -60,11 +60,10 @@
 		</dependency>
  
  		<!-- https://mvnrepository.com/artifact/org.springframework/spring-jms -->
-		<dependency>
-		    <groupId>org.springframework</groupId>
-		    <artifactId>spring-jms</artifactId>
-		    <version>6.1.6</version>
-		</dependency>
+                <dependency>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jms</artifactId>
+                </dependency>
 		<!-- https://mvnrepository.com/artifact/jakarta.jms/jakarta.jms-api -->
 		<dependency>
 		    <groupId>jakarta.jms</groupId>


### PR DESCRIPTION
## Summary
- upgrade Spring Boot version to 3.4.7
- rely on Spring Boot BOM for spring-jms version

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_686314769f048330ad16878d35dc0bfc