### PR TITLE
Switch to Apache Tika for text extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ An embedded ActiveMQ broker will start automatically on `localhost:61616` with t
 
 ## Text Extraction
 
-PDF files are processed using Azure Document Intelligence while other document
-types are sent to the Unstructured API. Configure the endpoints and API keys in
-`application.yml` under `azure.document` and `unstructured.api`.
+PDF files are processed using Azure Document Intelligence. Other document
+types are parsed locally with Apache Tika. Configure the Azure endpoint and
+key in `application.yml` under `azure.document`.

--- a/src/main/java/com/example/ingestion/service/TextExtractorService.java
+++ b/src/main/java/com/example/ingestion/service/TextExtractorService.java
@@ -6,28 +6,17 @@ import com.azure.ai.formrecognizer.documentanalysis.models.DocumentLine;
 import com.azure.ai.formrecognizer.documentanalysis.models.DocumentPage;
 import com.azure.core.util.BinaryData;
 import com.example.ingestion.etl.Extractor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.apache.tika.Tika;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
 import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 
 @Service
 public class TextExtractorService implements Extractor<InputStream, String> {
 
     private final DocumentAnalysisClient documentClient;
-    private final RestTemplate restTemplate = new RestTemplate();
-
-    @Value("${unstructured.api.url}")
-    private String unstructuredUrl;
-
-    @Value("${unstructured.api.key}")
-    private String unstructuredKey;
+    private final Tika tika = new Tika();
 
     public TextExtractorService(DocumentAnalysisClient documentClient) {
         this.documentClient = documentClient;
@@ -48,20 +37,7 @@ public class TextExtractorService implements Extractor<InputStream, String> {
                 }
                 return sb.toString();
             } else {
-                HttpHeaders headers = new HttpHeaders();
-                headers.setBearerAuth(unstructuredKey);
-                headers.setContentType(MediaType.MULTIPART_FORM_DATA);
-                ByteArrayResource resource = new ByteArrayResource(data) {
-                    @Override
-                    public String getFilename() {
-                        return filename == null ? "file" : filename;
-                    }
-                };
-                org.springframework.util.LinkedMultiValueMap<String, Object> body = new org.springframework.util.LinkedMultiValueMap<>();
-                body.add("files", resource);
-                HttpEntity<org.springframework.util.MultiValueMap<String, Object>> request = new HttpEntity<>(body, headers);
-                ResponseEntity<String> response = restTemplate.postForEntity(unstructuredUrl, request, String.class);
-                return response.getBody();
+                return tika.parseToString(new ByteArrayInputStream(data));
             }
         } catch (Exception e) {
             throw new RuntimeException("Text extraction failed", e);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,3 @@ azure:
   document:
     endpoint: https://your-form-recognizer.cognitiveservices.azure.com/
     api-key: your-form-recognizer-key
-unstructured:
-  api:
-    url: https://api.unstructured.io/general/v0/general
-    key: your-api-key


### PR DESCRIPTION
## Summary
- switch text extraction service to use Apache Tika for non-PDF files
- remove Unstructured API configuration
- update documentation to mention Tika

## Testing
- `mvn -q test` *(fails: could not download Maven parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686434a01f58833082917470e020fb92