### PR TITLE
Fix Azure blob upload length handling

### DIFF
--- a/src/main/java/com/example/ingestion/service/AzureBlobFileStorageService.java
+++ b/src/main/java/com/example/ingestion/service/AzureBlobFileStorageService.java
@@ -28,6 +28,12 @@ public class AzureBlobFileStorageService implements FileStorageService {
                 .blobName(filename)
                 .buildClient()
                 .getBlockBlobClient();
-        client.upload(BinaryData.fromStream(content), true);
+
+        try {
+            byte[] data = content.readAllBytes();
+            client.upload(BinaryData.fromBytes(data), true);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to store file to Azure Blob Storage", e);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- load the input stream fully before uploading to Azure

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68643e16b6ec833085181c712a7dd988