### PR TITLE
Use Spring ETL text splitter for chunking

### DIFF
--- a/src/main/java/com/example/ingestion/service/TextChunker.java
+++ b/src/main/java/com/example/ingestion/service/TextChunker.java
@@ -1,19 +1,20 @@
 package com.example.ingestion.service;
 
-import org.springframework.stereotype.Service;
-
-
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.transformer.splitter.TokenTextSplitter;
+import org.springframework.stereotype.Service;
 
 @Service
 public class TextChunker {
 
+    private final TokenTextSplitter splitter = new TokenTextSplitter();
+
     public List<String> transform(String text) {
-        return Arrays.stream(text.split("\n\n"))
-                     .map(String::trim)
-                     .filter(s -> !s.isEmpty())
-                     .collect(Collectors.toList());
+        List<Document> documents = splitter.split(new Document(text));
+        return documents.stream()
+                .map(Document::getText)
+                .toList();
     }
 }

--- a/src/test/java/com/example/ingestion/service/TextChunkerTest.java
+++ b/src/test/java/com/example/ingestion/service/TextChunkerTest.java
@@ -14,7 +14,7 @@ public class TextChunkerTest {
     public void testChunk() {
         String text = "Paragraph one.\n\nParagraph two.";
         List<String> chunks = chunker.transform(text);
-        assertEquals(2, chunks.size());
+        assertEquals(1, chunks.size());
         assertTrue(chunks.get(0).contains("Paragraph one"));
     }
 }


### PR DESCRIPTION
## Summary
- replace custom chunk splitting with `TokenTextSplitter`
- adjust unit test for new behaviour

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6866b02c1c848330836af65beb920244